### PR TITLE
Prepare version 0.5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,15 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
   - ruby-head
   - jruby
   - jruby-head
+
+before_install:
+  - which bundle >/dev/null 2>&1 || gem install bundler
 
 matrix:
   allow_failures:

--- a/lib/rgl/adjacency.rb
+++ b/lib/rgl/adjacency.rb
@@ -77,7 +77,7 @@ module RGL
     # Complexity is O(1), because the vertices are kept in a Hash containing
     # as values the lists of adjacent vertices of _v_.
     #
-    def has_vertex? (v)
+    def has_vertex?(v)
       @vertices_dict.has_key?(v)
     end
 
@@ -87,7 +87,7 @@ module RGL
     # ---
     # MutableGraph interface.
     #
-    def has_edge? (u, v)
+    def has_edge?(u, v)
       has_vertex?(u) && @vertices_dict[u].include?(v)
     end
 

--- a/lib/rgl/base.rb
+++ b/lib/rgl/base.rb
@@ -4,7 +4,7 @@
 # library. The main module is RGL::Graph which defines the abstract behavior of
 # all graphs in the library.
 
-RGL_VERSION = "0.5.3"
+RGL_VERSION = "0.5.4"
 
 module RGL
   class NotDirectedError < RuntimeError; end

--- a/rgl.gemspec
+++ b/rgl.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   #### Dependencies and requirements.
 
-  s.add_dependency 'stream',     '~> 0.5.0'
+  s.add_dependency 'stream',     '~> 0.5.2'
   s.add_dependency 'lazy_priority_queue', '~> 0.1.0'
 
   s.add_development_dependency 'rake'
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
 
   #### Documentation and testing.
 
-  s.has_rdoc = true
   s.extra_rdoc_files = ['README.md']
   s.rdoc_options += [
       '--title', 'RGL - Ruby Graph Library',


### PR DESCRIPTION
- Fix travis-ci errors
- Add new ruby versions
- Fix gemspec errors
- Fix lint warnings
- Use version stream 0.5.2